### PR TITLE
GDET-57: 퀴즈별로 너무 많은 스크린샷이 저장되는 문제 수정

### DIFF
--- a/aws_lambdas/daily_quiz/config.py
+++ b/aws_lambdas/daily_quiz/config.py
@@ -6,6 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Config(BaseSettings):
     DATABASE_LAMBDA_NAME: str = "database"
     DAILY_QUIZ_CNT: int = 5
+    QUIZ_SCREENSHOT_CNT: int = 5
     GAME_GENERES: Sequence[str] = [
         "Action",
         "Adventure",

--- a/aws_lambdas/daily_quiz/daily_quiz/serivce.py
+++ b/aws_lambdas/daily_quiz/daily_quiz/serivce.py
@@ -1,3 +1,4 @@
+import random
 from collections.abc import Iterable
 from datetime import date, timedelta
 
@@ -15,7 +16,8 @@ def create_quizzes(steam_api: SteamAPI, games: Iterable[Game]) -> list[SaveQuiz]
     for game in games:
         # 스크린샷 크롤링
         screenshots = scrap_screenshots(steam_api, game)
-        quizzes.append(SaveQuiz(screenshots=screenshots))
+        quiz_screenshots = random.sample(screenshots, k=setting.QUIZ_SCREENSHOT_CNT)
+        quizzes.append(SaveQuiz(screenshots=quiz_screenshots))
 
     return quizzes
 

--- a/aws_lambdas/tests/daily_quiz/daily_quiz/test_create_quizzes.py
+++ b/aws_lambdas/tests/daily_quiz/daily_quiz/test_create_quizzes.py
@@ -1,0 +1,27 @@
+import pytest
+
+from daily_quiz.config import setting
+from daily_quiz.daily_quiz.serivce import create_quizzes
+from tests.daily_quiz.utils.mock_steam_api import MockSteamAPI
+from tests.daily_quiz.utils.model import create_random_game
+
+
+@pytest.mark.parametrize("game_cnt", (0, 5, 10))
+def test_create_quizzes는_게임_개수만큼_퀴즈를_만들어야한다(game_cnt: int):
+    games = [create_random_game() for _ in range(game_cnt)]
+    steam_api = MockSteamAPI()
+
+    quizzes = create_quizzes(steam_api, games)
+
+    assert len(quizzes) == game_cnt
+
+
+@pytest.mark.parametrize("screenshot_cnt", (0, 5, 10))
+def test_create_quizzes는_퀴즈별로_설정값만큼_스크린샷을_할당해야_한다(screenshot_cnt: int):
+    setting.QUIZ_SCREENSHOT_CNT = screenshot_cnt
+    games = [create_random_game() for _ in range(5)]
+    steam_api = MockSteamAPI()
+
+    quizzes = create_quizzes(steam_api, games)
+    for quiz in quizzes:
+        assert len(quiz.screenshots) == screenshot_cnt


### PR DESCRIPTION
## 새로운 기능

- 퀴즈별로 스크린샷이 5개만 필요하지만 많은 수를 저장하는 문제를 해결했습니다.